### PR TITLE
fix: Ad debug dialog on android devices

### DIFF
--- a/android/src/main/java/com/matejdr/admanager/BannerAdView.java
+++ b/android/src/main/java/com/matejdr/admanager/BannerAdView.java
@@ -1,5 +1,5 @@
 package com.matejdr.admanager;
-
+import android.app.Activity;
 import android.content.Context;
 import android.location.Location;
 import android.os.Bundle;
@@ -34,7 +34,7 @@ import com.matejdr.admanager.utils.Targeting;
 class BannerAdView extends ReactViewGroup implements AppEventListener, LifecycleEventListener {
 
     protected AdManagerAdView adView;
-
+    Activity currentActivityContext = null;
     String[] testDevices;
     AdSize[] validAdSizes;
     String adUnitID;
@@ -52,6 +52,7 @@ class BannerAdView extends ReactViewGroup implements AppEventListener, Lifecycle
 
     public BannerAdView(final Context context, ReactApplicationContext applicationContext) {
         super(context);
+        currentActivityContext = applicationContext.getCurrentActivity();
         applicationContext.addLifecycleEventListener(this);
         this.createAdView();
     }
@@ -59,14 +60,13 @@ class BannerAdView extends ReactViewGroup implements AppEventListener, Lifecycle
     private void createAdView() {
         if (this.adView != null) this.adView.destroy();
 
-        final Context context = getContext();
-        this.adView = new AdManagerAdView(context);
+        this.adView = new AdManagerAdView(currentActivityContext);
         this.adView.setAppEventListener(this);
         this.adView.setAdListener(new AdListener() {
             @Override
             public void onAdLoaded() {
-                int width = adView.getAdSize().getWidthInPixels(context);
-                int height = adView.getAdSize().getHeightInPixels(context);
+                int width = adView.getAdSize().getWidthInPixels(getContext());
+                int height = adView.getAdSize().getHeightInPixels(getContext());
                 int left = adView.getLeft();
                 int top = adView.getTop();
                 adView.measure(width, height);
@@ -316,6 +316,7 @@ class BannerAdView extends ReactViewGroup implements AppEventListener, Lifecycle
     @Override
     public void onHostDestroy() {
         if (this.adView != null) {
+            this.currentActivityContext = null;
             this.adView.destroy();
         }
     }


### PR DESCRIPTION
Addresses issue  #47
When using this library the ad debug options menu is not opening on android devices (although it works fine on ios). When trying to open the ad debug menu I see this error in logcat. (https://tppr.me/o1fcG)
This PR is my proposal to fix this issue for banner component.
After applying these changes the ad debug menu dialog is working correctly on android. (Tested on Android 9, 10).

 ![photo_2021-11-08 15 23 36](https://user-images.githubusercontent.com/84466612/140749729-f9caa85a-bc47-48e6-abce-6b0c558d9bf1.jpeg)

Looking forward to your feedback on it. I would be very grateful if you would consider including this in the next release of the library.
