### PR TITLE
fix: bump version facebook meditation adapter for Google Ads

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     implementation 'com.google.android.gms:play-services-ads:20.3.0'
-    implementation 'com.google.ads.mediation:facebook:5.10.0.0'
+    implementation 'com.google.ads.mediation:facebook:6.8.0.0'
 }
 
 def configureReactNativePom(def pom) {


### PR DESCRIPTION
Since v5.10.0.0 is no longer available at Maven, the latest version that is
available should be used.

For latest version, please refer to:
https://mvnrepository.com/artifact/com.google.ads.mediation/facebook