### PR TITLE
Fixed an issue with ad banner width

### DIFF
--- a/ios/RNAdManagerBannerView.m
+++ b/ios/RNAdManagerBannerView.m
@@ -16,6 +16,15 @@
 
 @implementation RNAdManagerBannerView
 
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+
+    CGRect frameRect = _bannerView.frame;
+    frameRect.size.width = CGRectGetWidth(self.bounds);
+    _bannerView.frame = frameRect;
+}
+
 - (void)dealloc
 {
 


### PR DESCRIPTION
When `adSize` is set to fluid, the ad banner currently takes up the width of the entire screen. This fix sets the ad banner's width to fit the parent view.