### PR TITLE
Change Google-Mobile-Ads-SDK dependency in Podspec

### DIFF
--- a/react-native-ad-manager.podspec
+++ b/react-native-ad-manager.podspec
@@ -20,6 +20,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency 'Google-Mobile-Ads-SDK', '~> 9.0.0'
+  s.dependency 'Google-Mobile-Ads-SDK', '~> 9.0'
   s.dependency "GoogleMobileAdsMediationFacebook"
 end


### PR DESCRIPTION
We don't need to rely on patch version for this SDK, which was blocking other Pods like Firebase Analytics to be installed with the most recent version.

This change has been tested in a full-featured project and was working without any issues.