### PR TITLE
fix: ajust error dependence on Google-Mobile-Ads-SDK

### DIFF
--- a/react-native-ad-manager.podspec
+++ b/react-native-ad-manager.podspec
@@ -20,6 +20,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency 'Google-Mobile-Ads-SDK', '~> 9.0.0'
+  s.dependency 'Google-Mobile-Ads-SDK', '~> 9.14.0'
   s.dependency "GoogleMobileAdsMediationFacebook"
 end


### PR DESCRIPTION
I get error, after update firebase analytics .

my version  "@react-native-firebase/analytics": "^16.5.0",


<img width="732" alt="Screen Shot 2023-01-15 at 10 41 36" src="https://user-images.githubusercontent.com/34237655/212544193-8ac82505-df32-4692-ab26-d016889b6d95.png">


this PR update Google-Mobile-Ads-SDK to resolve dependency error 
