### PR TITLE
feat: upgrade Google-Mobile-Ads-SDK from 9.0.0 to 9.14.0

### DIFF
--- a/react-native-ad-manager.podspec
+++ b/react-native-ad-manager.podspec
@@ -20,6 +20,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency 'Google-Mobile-Ads-SDK', '~> 9.0.0'
+  s.dependency 'Google-Mobile-Ads-SDK', '~> 9.14.0'
   s.dependency "GoogleMobileAdsMediationFacebook"
 end


### PR DESCRIPTION
Version 9.14.0 Google-Mobile-Ads-SDK makes it compatible with recent versions of Firebase Analytics that use GoogleAppMeasurement (= 10.3.0), whereas version 9.0.0 depends on GoogleAppMeasurement (< 9.0, >= 7.0).