### PR TITLE
Restore null check around setAdUnitId

### DIFF
--- a/android/src/main/java/com/matejdr/admanager/BannerAdView.java
+++ b/android/src/main/java/com/matejdr/admanager/BannerAdView.java
@@ -286,7 +286,9 @@ class BannerAdView extends ReactViewGroup implements AppEventListener, Lifecycle
             this.createAdView();
         }
         this.adUnitID = adUnitID;
-        this.adManagerAdView.setAdUnitId(adUnitID);
+        if (this.adManagerAdView != null) {
+            this.adManagerAdView.setAdUnitId(adUnitID);
+        }
     }
 
     public void setTestDevices(String[] testDevices) {


### PR DESCRIPTION
This is a follow-up to #86, which was subsequently reverted via ef79c734bd9cd4b055339d38e2af5f024b486996...

I continue to get this crash reported from production:
![image](https://user-images.githubusercontent.com/5598961/230610693-649384a3-53b0-428b-baa7-cf032388c284.png)

The original fix attempt was incorrect because it moved the logic inside the `if (this.adUnitID != null) {` block. This change keeps everything in place...just adds the null check.