### PR TITLE
Android -  add null check before accessing test devices array

### DIFF
--- a/android/src/main/java/com/matejdr/admanager/RNAdManageNativeManager.java
+++ b/android/src/main/java/com/matejdr/admanager/RNAdManageNativeManager.java
@@ -48,9 +48,11 @@ public class RNAdManageNativeManager extends ReactContextBaseJavaModule {
         final AdsManagerProperties adsManagerProperties = new AdsManagerProperties();
         adsManagerProperties.setAdUnitID(adUnitID);
 
-        ReadableNativeArray nativeArray = (ReadableNativeArray) testDevices;
-        ArrayList<Object> list = nativeArray.toArrayList();
-        adsManagerProperties.setTestDevices(list.toArray(new String[list.size()]));
+        if (testDevices != null && testDevices.size() > 0) {
+            ReadableNativeArray nativeArray = (ReadableNativeArray) testDevices;
+            ArrayList<Object> list = nativeArray.toArrayList();
+            adsManagerProperties.setTestDevices(list.toArray(new String[list.size()]));
+        }
 
         propertiesMap.put(adUnitID, adsManagerProperties);
     }

--- a/react-native-ad-manager.podspec
+++ b/react-native-ad-manager.podspec
@@ -20,6 +20,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency 'Google-Mobile-Ads-SDK', '~> 9.0.0'
+  s.dependency 'Google-Mobile-Ads-SDK', '~> 9.14.0'
   s.dependency "GoogleMobileAdsMediationFacebook"
 end


### PR DESCRIPTION
For Android, the `init` method is attempting to call `toArrayList()` on a possible `null` array. Add check to avoid null pointer

![WhatsApp Image 2023-05-16 at 22 20 26](https://github.com/NZME/react-native-ad-manager/assets/11378830/b1abc4c9-cf63-4bd3-9162-6259f4aa7ce1)
