### PR TITLE
Interstitial ads - It shows up only once and isReady crashes on Android

### DIFF
--- a/android/src/main/java/com/matejdr/admanager/RNAdManagerInterstitial.java
+++ b/android/src/main/java/com/matejdr/admanager/RNAdManagerInterstitial.java
@@ -314,7 +314,7 @@ public class RNAdManagerInterstitial extends ReactContextBaseJavaModule {
         new Handler(Looper.getMainLooper()).post(new Runnable() {
             @Override
             public void run() {
-                callback.invoke(mInterstitialAd);
+                callback.invoke(mInterstitialAd != null);
             }
         });
     }
@@ -322,11 +322,11 @@ public class RNAdManagerInterstitial extends ReactContextBaseJavaModule {
      // Required for rn built in EventEmitter Calls.
      @ReactMethod
      public void addListener(String eventName) {
- 
+
      }
- 
+
      @ReactMethod
      public void removeListeners(Integer count) {
- 
+
      }
 }

--- a/ios/RNAdManagerInterstitial.m
+++ b/ios/RNAdManagerInterstitial.m
@@ -65,8 +65,8 @@ RCT_EXPORT_METHOD(requestAd:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromise
     _requestAdResolve = nil;
     _requestAdReject = nil;
 
-    BOOL hasBeenUsed =  [_interstitial canPresentFromRootViewController:[UIApplication sharedApplication].delegate.window.rootViewController error:nil];
-    if (hasBeenUsed || _interstitial == nil) {
+    BOOL isReady =  [_interstitial canPresentFromRootViewController:[UIApplication sharedApplication].delegate.window.rootViewController error:nil];
+    if (!isReady) {
         _requestAdResolve = resolve;
         _requestAdReject = reject;
 

--- a/src/CTKAdManagerInterstitial.ts
+++ b/src/CTKAdManagerInterstitial.ts
@@ -109,7 +109,7 @@ const showAd = (): Promise<null> => {
   return CTKInterstitial.showAd();
 }
 
-const isReady = (callback: (isReady: number) => void): Promise<null> => {
+const isReady = (callback: (isReady: boolean) => void): Promise<null> => {
   return CTKInterstitial.isReady(callback);
 }
 


### PR DESCRIPTION
This PR aims to fix the following [issue](https://github.com/NZME/react-native-ad-manager/issues/124).

We are using our patch at the moment, but it would be nice to have this PR merged for the next release, I believe this issue is quite critical, especially on Android where it crashes.

Thank you guys!