### PR TITLE
Enabled app interstitials to re-appear after a number of user clicks on iOS

### DIFF
--- a/ios/RNAdManagerInterstitial.m
+++ b/ios/RNAdManagerInterstitial.m
@@ -180,6 +180,7 @@ RCT_EXPORT_METHOD(isReady:(RCTResponseSenderBlock)callback)
     if (hasListeners) {
         [self sendEventWithName:kEventAdClosed body:nil];
     }
+    _interstitial = nil;
 }
 
 @end


### PR DESCRIPTION
Currently there's a bug where on iOS interstitial ads will only appear once, then not re-appear again after a certain number of user clicks (configured at 15).
According to [Google's documentation](https://developers.google.com/admob/ios/interstitial), GADInterstitialAd is a one-time-use object. This means that once an interstitial ad is shown, it cannot be shown again. A best practice is to load another interstitial ad in the adDidDismissFullScreenContent: method on GADFullScreenContentDelegate so that the next interstitial ad starts loading as soon as the previous one is dismissed.
This tiny PR re-initialises another interstitial object in the aforementioned method so that `requestAd` functions correctly.
Tested locally on iOS device and emulator.