### PR TITLE
NonPersonalizedAds - Missing network extra to toggle npa parameter

### DIFF
--- a/src/CTKAdManagerAdaptiveBanner.tsx
+++ b/src/CTKAdManagerAdaptiveBanner.tsx
@@ -44,6 +44,8 @@ interface IAdManagerAdaptiveBannerPropsBase extends ViewProps {
   testDevices?: string[];
 
   targeting?: IAdManagerTargeting;
+
+  servePersonalizedAds?: boolean;
 }
 
 interface IAdManagerAdaptiveBannerProps

--- a/src/CTKAdManagerBanner.tsx
+++ b/src/CTKAdManagerBanner.tsx
@@ -5,8 +5,8 @@ import {
   ViewProps,
   findNodeHandle,
   NativeSyntheticEvent,
-  DeviceEventEmitter,  
-  EventSubscription
+  DeviceEventEmitter,
+  EventSubscription,
 } from 'react-native';
 import { createErrorFromErrorData } from './utils';
 import type {
@@ -52,10 +52,12 @@ interface IAdManagerBannerPropsBase extends ViewProps {
   testDevices?: string[];
 
   targeting?: IAdManagerTargeting;
+
+  servePersonalizedAds?: boolean;
 }
 
 interface IAdManagerBannerProps extends IAdManagerBannerPropsBase {
-  // onError is a callback function sent from parent RN component of your RN app, aka: the error handler. 
+  // onError is a callback function sent from parent RN component of your RN app, aka: the error handler.
   // so if your RN App wants to handle the error, please pass in the "onError" function.
   onError?: (eventData: Error) => void;
   /**
@@ -92,7 +94,9 @@ interface IAdManagerBannerNativeProps extends IAdManagerBannerPropsBase {
   onAppEvent?: (event: NativeSyntheticEvent<IAdManagerEventAppEvent>) => void;
   onAdOpened?: (event: NativeSyntheticEvent<IAdManagerEventBase>) => void;
   onAdClosed?: (event: NativeSyntheticEvent<IAdManagerEventBase>) => void;
-  onAdRecordImpression?: (event: NativeSyntheticEvent<IAdManagerEventBase>) => void;
+  onAdRecordImpression?: (
+    event: NativeSyntheticEvent<IAdManagerEventBase>
+  ) => void;
 }
 
 const ComponentName = 'CTKBannerView';
@@ -113,7 +117,10 @@ export class Banner extends React.Component<
 
   constructor(props: IAdManagerBannerProps) {
     super(props);
-    this.hasOnErrorFromParent = Object.prototype.hasOwnProperty.call(props, 'onError');
+    this.hasOnErrorFromParent = Object.prototype.hasOwnProperty.call(
+      props,
+      'onError'
+    );
     this.handleSizeChange = this.handleSizeChange.bind(this);
     this.state = {
       style: {},
@@ -137,21 +144,24 @@ export class Banner extends React.Component<
   }
 
   componentDidMount() {
-    this.customListener= DeviceEventEmitter.addListener('onError',eventData=>{
-      this.setState({ error: eventData });
-      if (this.hasOnErrorFromParent && this.props.onError) {      
-        this.props.onError(eventData);
+    this.customListener = DeviceEventEmitter.addListener(
+      'onError',
+      (eventData) => {
+        this.setState({ error: eventData });
+        if (this.hasOnErrorFromParent && this.props.onError) {
+          this.props.onError(eventData);
+        }
       }
-    });    
+    );
     this.loadBanner();
   }
-  
+
   componentWillUnmount() {
     if (this.customListener) {
       this.customListener.remove();
     }
   }
-  
+
   loadBanner() {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this),
@@ -191,7 +201,8 @@ export class Banner extends React.Component<
           this.props.onAdClosed && this.props.onAdClosed(event.nativeEvent)
         }
         onAdRecordImpression={(event) =>
-          this.props.onAdRecordImpression && this.props.onAdRecordImpression(event.nativeEvent)
+          this.props.onAdRecordImpression &&
+          this.props.onAdRecordImpression(event.nativeEvent)
         }
       />
     );

--- a/src/CTKAdManagerInterstitial.ts
+++ b/src/CTKAdManagerInterstitial.ts
@@ -101,17 +101,21 @@ const setTargeting = (targeting: IAdManagerTargeting) => {
   CTKInterstitial.setTargeting(targeting);
 };
 
+const setServePersonalizedAds = (servePersonalizedAds: boolean) => {
+  CTKInterstitial.setServePersonalizedAds(servePersonalizedAds);
+};
+
 const requestAd = (): Promise<null> => {
   return CTKInterstitial.requestAd();
-}
+};
 
 const showAd = (): Promise<null> => {
   return CTKInterstitial.showAd();
-}
+};
 
 const isReady = (callback: (isReady: boolean) => void): Promise<null> => {
   return CTKInterstitial.isReady(callback);
-}
+};
 
 export default {
   addEventListener,
@@ -123,5 +127,6 @@ export default {
   setTargeting,
   requestAd,
   showAd,
-  isReady
-}
+  setServePersonalizedAds,
+  isReady,
+};

--- a/src/native-ads/withNativeAd.tsx
+++ b/src/native-ads/withNativeAd.tsx
@@ -37,6 +37,7 @@ interface INativeAdPropsBase extends ViewProps {
   validAdTypes?: ('banner' | 'native' | 'template')[];
   customClickTemplateIds?: string[];
   targeting?: IAdManagerTargeting;
+  servePersonalizedAds?: boolean;
 }
 
 interface INativeAdNativeProps extends INativeAdPropsBase {
@@ -60,7 +61,9 @@ interface INativeAdNativeProps extends INativeAdPropsBase {
   onAdCustomClick?: (
     event: NativeSyntheticEvent<IAdManagerEventCustomClick>
   ) => void;
-  onAdRecordImpression?: (event: NativeSyntheticEvent<IAdManagerEventBase>) => void;
+  onAdRecordImpression?: (
+    event: NativeSyntheticEvent<IAdManagerEventBase>
+  ) => void;
 }
 
 interface INativeAdProps extends INativeAdPropsBase {
@@ -276,11 +279,13 @@ export default (Component: JSXElementConstructor<any>) =>
             this.props.onAdCustomClick(event.nativeEvent)
           }
           onAdRecordImpression={(event) =>
-            this.props.onAdRecordImpression && this.props.onAdRecordImpression(event.nativeEvent)
+            this.props.onAdRecordImpression &&
+            this.props.onAdRecordImpression(event.nativeEvent)
           }
           targeting={this.props.targeting}
           customClickTemplateIds={this.props.customClickTemplateIds}
           adsManager={adsManager.toJSON()}
+          servePersonalizedAds={this.props.servePersonalizedAds}
         >
           {this.renderAdComponent(rest)}
         </NativeAdView>


### PR DESCRIPTION
We are missing a key property in the network parameters that is **npa**.
This property allows us to toggle whether we want to request personalized ads for the current user.

Whenever from our custom CMP SDK (For example OneTrust) we detect that the user has changes our permission to track its data through advs, we need to properly tell ad manager to avoid serving personalized ads. Otherwise we are not compliant, especially in Europe, under GDPR.

Here you can find sources:

1. [Google Group](https://groups.google.com/g/google-admob-ads-sdk/c/PWbDCkwGX3Y/m/-wqXiuQIAwAJ)