### PR TITLE
fix: wrong typescript correlator property setup

### DIFF
--- a/src/AdManagerTypes.ts
+++ b/src/AdManagerTypes.ts
@@ -44,11 +44,6 @@ export interface IAdManagerTargeting {
    *  information to third-party ad networks if required.
    */
   location?: IAdManagerTargetingLocation;
-
-  /**
-   * Correlator string to pass to ad loader.
-   */
-  correlator?: string;
 }
 
 export interface IAdManagerTemplateImage {

--- a/src/CTKAdManagerAdaptiveBanner.tsx
+++ b/src/CTKAdManagerAdaptiveBanner.tsx
@@ -44,6 +44,11 @@ interface IAdManagerAdaptiveBannerPropsBase extends ViewProps {
   testDevices?: string[];
 
   targeting?: IAdManagerTargeting;
+
+  /**
+   * Correlator string to pass to ad loader.
+   */
+  correlator?: string;
 }
 
 interface IAdManagerAdaptiveBannerProps

--- a/src/CTKAdManagerBanner.tsx
+++ b/src/CTKAdManagerBanner.tsx
@@ -5,7 +5,7 @@ import {
   ViewProps,
   findNodeHandle,
   NativeSyntheticEvent,
-  DeviceEventEmitter,  
+  DeviceEventEmitter,
   EventSubscription
 } from 'react-native';
 import { createErrorFromErrorData } from './utils';
@@ -52,10 +52,15 @@ interface IAdManagerBannerPropsBase extends ViewProps {
   testDevices?: string[];
 
   targeting?: IAdManagerTargeting;
+
+  /**
+   * Correlator string to pass to ad loader.
+   */
+  correlator?: string;
 }
 
 interface IAdManagerBannerProps extends IAdManagerBannerPropsBase {
-  // onError is a callback function sent from parent RN component of your RN app, aka: the error handler. 
+  // onError is a callback function sent from parent RN component of your RN app, aka: the error handler.
   // so if your RN App wants to handle the error, please pass in the "onError" function.
   onError?: (eventData: Error) => void;
   /**
@@ -139,19 +144,19 @@ export class Banner extends React.Component<
   componentDidMount() {
     this.customListener= DeviceEventEmitter.addListener('onError',eventData=>{
       this.setState({ error: eventData });
-      if (this.hasOnErrorFromParent && this.props.onError) {      
+      if (this.hasOnErrorFromParent && this.props.onError) {
         this.props.onError(eventData);
       }
-    });    
+    });
     this.loadBanner();
   }
-  
+
   componentWillUnmount() {
     if (this.customListener) {
       this.customListener.remove();
     }
   }
-  
+
   loadBanner() {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this),

--- a/src/native-ads/withNativeAd.tsx
+++ b/src/native-ads/withNativeAd.tsx
@@ -31,12 +31,12 @@ import { LINKING_ERROR } from '../Constants';
  */
 interface INativeAdPropsBase extends ViewProps {
   adSize?: string;
-  correlator?: string;
   customTemplateIds?: string[];
   validAdSizes?: string[];
   validAdTypes?: ('banner' | 'native' | 'template')[];
   customClickTemplateIds?: string[];
   targeting?: IAdManagerTargeting;
+  correlator?: string;
 }
 
 interface INativeAdNativeProps extends INativeAdPropsBase {


### PR DESCRIPTION
This PR aims to fix the following [issue](https://github.com/NZME/react-native-ad-manager/issues/135).

I've moved the correlator typescript configuration from the targeting object to the root props interface.
This way we fixes the wrong typescript suggestions related to missing correlator prop in all components.