### PR TITLE
MA-1733: Deprecate programmatic ads logic

### DIFF
--- a/android/src/main/java/com/matejdr/admanager/AdaptiveBannerAdView.java
+++ b/android/src/main/java/com/matejdr/admanager/AdaptiveBannerAdView.java
@@ -48,8 +48,8 @@ class AdaptiveBannerAdView extends ReactViewGroup implements AppEventListener, L
     String publisherProvidedID;
     Location location;
     String correlator;
-    Boolean servePersonalizedAds = true;
-    Boolean allowDataProcessing = true;
+    Boolean servePersonalizedAds = false;
+    Boolean allowDataProcessing = false;
 
     int top;
     int left;

--- a/android/src/main/java/com/matejdr/admanager/AdaptiveBannerAdView.java
+++ b/android/src/main/java/com/matejdr/admanager/AdaptiveBannerAdView.java
@@ -49,6 +49,7 @@ class AdaptiveBannerAdView extends ReactViewGroup implements AppEventListener, L
     Location location;
     String correlator;
     Boolean servePersonalizedAds = true;
+    Boolean allowDataProcessing = true;
 
     int top;
     int left;
@@ -212,6 +213,10 @@ class AdaptiveBannerAdView extends ReactViewGroup implements AppEventListener, L
             bundle.putInt("npa", 1);
         }
 
+        if (!allowDataProcessing) {
+            bundle.putInt("rdp", 1);
+        }
+
         adRequestBuilder.addNetworkExtrasBundle(AdMobAdapter.class, bundle);
 
         // Targeting
@@ -315,6 +320,10 @@ class AdaptiveBannerAdView extends ReactViewGroup implements AppEventListener, L
 
     public void setServePersonalizedAds(Boolean servePersonalizedAds) {
         this.servePersonalizedAds = servePersonalizedAds;
+    }
+
+    public void setAllowDataProcessing(Boolean allowDataProcessing) {
+        this.allowDataProcessing = allowDataProcessing;
     }
 
     @Override

--- a/android/src/main/java/com/matejdr/admanager/AdaptiveBannerAdView.java
+++ b/android/src/main/java/com/matejdr/admanager/AdaptiveBannerAdView.java
@@ -48,6 +48,7 @@ class AdaptiveBannerAdView extends ReactViewGroup implements AppEventListener, L
     String publisherProvidedID;
     Location location;
     String correlator;
+    Boolean servePersonalizedAds = true;
 
     int top;
     int left;
@@ -207,6 +208,10 @@ class AdaptiveBannerAdView extends ReactViewGroup implements AppEventListener, L
         Bundle bundle = new Bundle();
         bundle.putString("correlator", correlator);
 
+        if (!servePersonalizedAds) {
+            bundle.putInt("npa", 1);
+        }
+
         adRequestBuilder.addNetworkExtrasBundle(AdMobAdapter.class, bundle);
 
         // Targeting
@@ -306,6 +311,10 @@ class AdaptiveBannerAdView extends ReactViewGroup implements AppEventListener, L
 
     public void setCorrelator(String correlator) {
         this.correlator = correlator;
+    }
+
+    public void setServePersonalizedAds(Boolean servePersonalizedAds) {
+        this.servePersonalizedAds = servePersonalizedAds;
     }
 
     @Override

--- a/android/src/main/java/com/matejdr/admanager/BannerAdView.java
+++ b/android/src/main/java/com/matejdr/admanager/BannerAdView.java
@@ -50,6 +50,8 @@ class BannerAdView extends ReactViewGroup implements AppEventListener, Lifecycle
     Location location;
     String correlator;
 
+    Boolean servePersonalizedAds = true;
+
     int top;
     int left;
     int width;
@@ -283,6 +285,10 @@ class BannerAdView extends ReactViewGroup implements AppEventListener, Lifecycle
             Bundle bundle = new Bundle();
             bundle.putString("correlator", correlator);
 
+            if (!servePersonalizedAds) {
+                bundle.putInt("npa", 1);
+            }
+
             adRequestBuilder.addNetworkExtrasBundle(AdMobAdapter.class, bundle);
 
             // Targeting
@@ -444,6 +450,14 @@ class BannerAdView extends ReactViewGroup implements AppEventListener, Lifecycle
             this.correlator = correlator;
         } catch (Exception e) {
             sendErrorEvent("Error found at ad manager when setCorrelator(): " + e.getMessage() + "!");
+        }
+    }
+
+    public void setServePersonalizedAds(Boolean servePersonalizedAds) {
+        try {
+            this.servePersonalizedAds = servePersonalizedAds;
+        } catch (Exception e) {
+            sendErrorEvent("Error found at ad manager when setServePersonalizedAds(): " + e.getMessage() + "!");
         }
     }
 

--- a/android/src/main/java/com/matejdr/admanager/BannerAdView.java
+++ b/android/src/main/java/com/matejdr/admanager/BannerAdView.java
@@ -51,6 +51,7 @@ class BannerAdView extends ReactViewGroup implements AppEventListener, Lifecycle
     String correlator;
 
     Boolean servePersonalizedAds = true;
+    Boolean allowDataProcessing = false;
 
     int top;
     int left;
@@ -289,6 +290,10 @@ class BannerAdView extends ReactViewGroup implements AppEventListener, Lifecycle
                 bundle.putInt("npa", 1);
             }
 
+            if (!allowDataProcessing) {
+                bundle.putInt("rdp", 1);
+            }
+
             adRequestBuilder.addNetworkExtrasBundle(AdMobAdapter.class, bundle);
 
             // Targeting
@@ -458,6 +463,14 @@ class BannerAdView extends ReactViewGroup implements AppEventListener, Lifecycle
             this.servePersonalizedAds = servePersonalizedAds;
         } catch (Exception e) {
             sendErrorEvent("Error found at ad manager when setServePersonalizedAds(): " + e.getMessage() + "!");
+        }
+    }
+
+    public void setAllowDataProcessing(Boolean allowDataProcessing) {
+        try {
+            this.allowDataProcessing = allowDataProcessing;
+        } catch (Exception e) {
+            sendErrorEvent("Error found at ad manager when setAllowDataProcessing(): " + e.getMessage() + "!");
         }
     }
 

--- a/android/src/main/java/com/matejdr/admanager/NativeAdViewContainer.java
+++ b/android/src/main/java/com/matejdr/admanager/NativeAdViewContainer.java
@@ -77,6 +77,7 @@ public class NativeAdViewContainer extends ReactViewGroup implements AppEventLis
     Location location;
     String correlator;
     Boolean servePersonalizedAds = true;
+    Boolean allowDataProcessing = false;
     List<String> customClickTemplateIds;
 
     /**
@@ -266,8 +267,11 @@ public class NativeAdViewContainer extends ReactViewGroup implements AppEventLis
                         correlator = (String) Targeting.getCorelator(adUnitID);
                     }
                     Bundle bundle = new Bundle();
-                    //Restrict data processing by default for all users
-                    bundle.putInt("rdp", 1);
+
+                    // Restrict data processing by default for all users
+                    if(!allowDataProcessing) { 
+                        bundle.putInt("rdp", 1);
+                    }
                     bundle.putString("correlator", correlator);
 
                     if (!servePersonalizedAds) {
@@ -648,6 +652,10 @@ public class NativeAdViewContainer extends ReactViewGroup implements AppEventLis
 
     public void setServePersonalizedAds(Boolean servePersonalizedAds) {
         this.servePersonalizedAds = servePersonalizedAds;
+    }
+
+    public void setAllowDataProcessing(Boolean allowDataProcessing) {
+        this.allowDataProcessing = allowDataProcessing;
     }
 
     public void setCustomClickTemplateIds(String[] customClickTemplateIds) {

--- a/android/src/main/java/com/matejdr/admanager/NativeAdViewContainer.java
+++ b/android/src/main/java/com/matejdr/admanager/NativeAdViewContainer.java
@@ -265,6 +265,8 @@ public class NativeAdViewContainer extends ReactViewGroup implements AppEventLis
                         correlator = (String) Targeting.getCorelator(adUnitID);
                     }
                     Bundle bundle = new Bundle();
+                    //Restrict data processing by default for all users
+                    bundle.putInt("rdp", 1);
                     bundle.putString("correlator", correlator);
 
                     adRequestBuilder.addNetworkExtrasBundle(AdMobAdapter.class, bundle);

--- a/android/src/main/java/com/matejdr/admanager/NativeAdViewContainer.java
+++ b/android/src/main/java/com/matejdr/admanager/NativeAdViewContainer.java
@@ -259,6 +259,8 @@ public class NativeAdViewContainer extends ReactViewGroup implements AppEventLis
                         correlator = (String) Targeting.getCorelator(adUnitID);
                     }
                     Bundle bundle = new Bundle();
+                    //Restrict data processing by default for all users
+                    bundle.putInt("rdp", 1);
                     bundle.putString("correlator", correlator);
 
                     adRequestBuilder.addNetworkExtrasBundle(AdMobAdapter.class, bundle);

--- a/android/src/main/java/com/matejdr/admanager/NativeAdViewContainer.java
+++ b/android/src/main/java/com/matejdr/admanager/NativeAdViewContainer.java
@@ -76,6 +76,7 @@ public class NativeAdViewContainer extends ReactViewGroup implements AppEventLis
     String publisherProvidedID;
     Location location;
     String correlator;
+    Boolean servePersonalizedAds = true;
     List<String> customClickTemplateIds;
 
     /**
@@ -267,6 +268,10 @@ public class NativeAdViewContainer extends ReactViewGroup implements AppEventLis
                     Bundle bundle = new Bundle();
                     bundle.putString("correlator", correlator);
 
+                    if (!servePersonalizedAds) {
+                        bundle.putInt("npa", 1);
+                    }
+
                     adRequestBuilder.addNetworkExtrasBundle(AdMobAdapter.class, bundle);
 
                     Bundle fbExtras = new FacebookExtras()
@@ -313,7 +318,7 @@ public class NativeAdViewContainer extends ReactViewGroup implements AppEventLis
                         }
 
                         // setLocation() became obsolete since GMA SDK version 21.0.0, link reference below:
-                        //          https://developers.google.com/admob/android/rel-notes                        
+                        //          https://developers.google.com/admob/android/rel-notes
                         //if (location != null) {
                         //    adRequestBuilder.setLocation(location);
                         //}
@@ -637,6 +642,10 @@ public class NativeAdViewContainer extends ReactViewGroup implements AppEventLis
 
     public void setCorrelator(String correlator) {
         this.correlator = correlator;
+    }
+
+    public void setServePersonalizedAds(Boolean servePersonalizedAds) {
+        this.servePersonalizedAds = servePersonalizedAds;
     }
 
     public void setCustomClickTemplateIds(String[] customClickTemplateIds) {

--- a/android/src/main/java/com/matejdr/admanager/RNAdManagerAdaptiveBannerViewManager.java
+++ b/android/src/main/java/com/matejdr/admanager/RNAdManagerAdaptiveBannerViewManager.java
@@ -33,6 +33,7 @@ public class RNAdManagerAdaptiveBannerViewManager extends ViewGroupManager<Adapt
     public static final String PROP_TARGETING = "targeting";
     public static final String PROP_CORRELATOR = "correlator";
     public static final String PROP_SERVE_PERSONALIZED_ADS = "servePersonalizedAds";
+    public static final String PROP_ALLOW_DATA_PROCESSING = "allowDataProcessing";
 
     public static final String EVENT_SIZE_CHANGE = "onSizeChange";
     public static final String EVENT_AD_LOADED = "onAdLoaded";
@@ -182,6 +183,11 @@ public class RNAdManagerAdaptiveBannerViewManager extends ViewGroupManager<Adapt
     @ReactProp(name = PROP_SERVE_PERSONALIZED_ADS)
     public void setServePersonalizedAds(final AdaptiveBannerAdView view, final Boolean servePersonalizedAds) {
         view.setServePersonalizedAds(servePersonalizedAds);
+    }
+
+    @ReactProp(name = PROP_ALLOW_DATA_PROCESSING)
+    public void setAllowDataProcessing(final AdaptiveBannerAdView view, final Boolean allowDataProcessing) {
+        view.setAllowDataProcessing(allowDataProcessing);
     }
 
     @Nullable

--- a/android/src/main/java/com/matejdr/admanager/RNAdManagerAdaptiveBannerViewManager.java
+++ b/android/src/main/java/com/matejdr/admanager/RNAdManagerAdaptiveBannerViewManager.java
@@ -32,6 +32,7 @@ public class RNAdManagerAdaptiveBannerViewManager extends ViewGroupManager<Adapt
     public static final String PROP_TEST_DEVICES = "testDevices";
     public static final String PROP_TARGETING = "targeting";
     public static final String PROP_CORRELATOR = "correlator";
+    public static final String PROP_SERVE_PERSONALIZED_ADS = "servePersonalizedAds";
 
     public static final String EVENT_SIZE_CHANGE = "onSizeChange";
     public static final String EVENT_AD_LOADED = "onAdLoaded";
@@ -176,6 +177,11 @@ public class RNAdManagerAdaptiveBannerViewManager extends ViewGroupManager<Adapt
     @ReactProp(name = PROP_CORRELATOR)
     public void setCorrelator(final AdaptiveBannerAdView view, final String correlator) {
         view.setCorrelator(correlator);
+    }
+
+    @ReactProp(name = PROP_SERVE_PERSONALIZED_ADS)
+    public void setServePersonalizedAds(final AdaptiveBannerAdView view, final Boolean servePersonalizedAds) {
+        view.setServePersonalizedAds(servePersonalizedAds);
     }
 
     @Nullable

--- a/android/src/main/java/com/matejdr/admanager/RNAdManagerBannerViewManager.java
+++ b/android/src/main/java/com/matejdr/admanager/RNAdManagerBannerViewManager.java
@@ -35,6 +35,7 @@ public class RNAdManagerBannerViewManager extends ViewGroupManager<BannerAdView>
     public static final String PROP_TARGETING = "targeting";
     public static final String PROP_CORRELATOR = "correlator";
     public static final String PROP_SERVE_PERSONALIZED_ADS = "servePersonalizedAds";
+    public static final String PROP_ALLOW_DATA_PROCESSING = "allowDataProcessing";
 
     public static final String EVENT_SIZE_CHANGE = "onSizeChange";
     public static final String EVENT_AD_LOADED = "onAdLoaded";
@@ -194,6 +195,11 @@ public class RNAdManagerBannerViewManager extends ViewGroupManager<BannerAdView>
     @ReactProp(name = PROP_SERVE_PERSONALIZED_ADS)
     public void setServePersonalizedAds(final BannerAdView view, final Boolean servePersonalizedAds) {
         view.setServePersonalizedAds(servePersonalizedAds);
+    }
+
+    @ReactProp(name = PROP_ALLOW_DATA_PROCESSING)
+    public void setAllowDataProcessing(final BannerAdView view, final Boolean allowDataProcessing) {
+        view.setAllowDataProcessing(allowDataProcessing);
     }
 
     @Nullable

--- a/android/src/main/java/com/matejdr/admanager/RNAdManagerBannerViewManager.java
+++ b/android/src/main/java/com/matejdr/admanager/RNAdManagerBannerViewManager.java
@@ -34,6 +34,7 @@ public class RNAdManagerBannerViewManager extends ViewGroupManager<BannerAdView>
     public static final String PROP_TEST_DEVICES = "testDevices";
     public static final String PROP_TARGETING = "targeting";
     public static final String PROP_CORRELATOR = "correlator";
+    public static final String PROP_SERVE_PERSONALIZED_ADS = "servePersonalizedAds";
 
     public static final String EVENT_SIZE_CHANGE = "onSizeChange";
     public static final String EVENT_AD_LOADED = "onAdLoaded";
@@ -188,6 +189,11 @@ public class RNAdManagerBannerViewManager extends ViewGroupManager<BannerAdView>
     @ReactProp(name = PROP_CORRELATOR)
     public void setCorrelator(final BannerAdView view, final String correlator) {
         view.setCorrelator(correlator);
+    }
+
+    @ReactProp(name = PROP_SERVE_PERSONALIZED_ADS)
+    public void setServePersonalizedAds(final BannerAdView view, final Boolean servePersonalizedAds) {
+        view.setServePersonalizedAds(servePersonalizedAds);
     }
 
     @Nullable

--- a/android/src/main/java/com/matejdr/admanager/RNAdManagerInterstitial.java
+++ b/android/src/main/java/com/matejdr/admanager/RNAdManagerInterstitial.java
@@ -60,6 +60,7 @@ public class RNAdManagerInterstitial extends ReactContextBaseJavaModule {
     ReactApplicationContext reactContext;
 
     private Promise mRequestAdPromise;
+    private Boolean servePersonalizedAds = true;
 
     public RNAdManagerInterstitial(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -142,6 +143,11 @@ public class RNAdManagerInterstitial extends ReactContextBaseJavaModule {
         }
     }
 
+    @ReactMethod
+    public void setServePersonalizedAds(Boolean servePersonalizedAds) {
+        this.servePersonalizedAds = servePersonalizedAds;
+    }
+
     private AdManagerAdRequest buildAdRequest() {
         AdManagerAdRequest.Builder adRequestBuilder = new AdManagerAdRequest.Builder();
 
@@ -202,6 +208,13 @@ public class RNAdManagerInterstitial extends ReactContextBaseJavaModule {
         //if (location != null) {
         //    adRequestBuilder.setLocation(location);
         //}
+
+        Bundle bundle = new Bundle();
+        if (!servePersonalizedAds) {
+            bundle.putInt("npa", 1);
+        }
+
+        adRequestBuilder.addNetworkExtrasBundle(AdMobAdapter.class, bundle);
 
         adRequest = adRequestBuilder.build();
 

--- a/android/src/main/java/com/matejdr/admanager/RNAdManagerInterstitial.java
+++ b/android/src/main/java/com/matejdr/admanager/RNAdManagerInterstitial.java
@@ -63,6 +63,7 @@ public class RNAdManagerInterstitial extends ReactContextBaseJavaModule {
 
     private Promise mRequestAdPromise;
     private Boolean servePersonalizedAds = true;
+    private Boolean allowDataProcessing = false;
 
     public RNAdManagerInterstitial(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -150,6 +151,11 @@ public class RNAdManagerInterstitial extends ReactContextBaseJavaModule {
         this.servePersonalizedAds = servePersonalizedAds;
     }
 
+    @ReactMethod
+    public void setAllowDataProcessing(Boolean allowDataProcessing) {
+        this.allowDataProcessing = allowDataProcessing;
+    }
+
     private AdManagerAdRequest buildAdRequest() {
         AdManagerAdRequest.Builder adRequestBuilder = new AdManagerAdRequest.Builder();
 
@@ -214,6 +220,10 @@ public class RNAdManagerInterstitial extends ReactContextBaseJavaModule {
         Bundle bundle = new Bundle();
         if (!servePersonalizedAds) {
             bundle.putInt("npa", 1);
+        }
+
+        if (!allowDataProcessing) {
+            bundle.putInt("rdp", 1);
         }
 
         adRequestBuilder.addNetworkExtrasBundle(AdMobAdapter.class, bundle);

--- a/android/src/main/java/com/matejdr/admanager/RNAdManagerInterstitial.java
+++ b/android/src/main/java/com/matejdr/admanager/RNAdManagerInterstitial.java
@@ -2,6 +2,7 @@ package com.matejdr.admanager;
 
 import android.app.Activity;
 import android.location.Location;
+import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 
@@ -19,6 +20,7 @@ import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.ReadableNativeArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.google.ads.mediation.admob.AdMobAdapter;
 import com.google.android.gms.ads.AdError;
 import com.google.android.gms.ads.FullScreenContentCallback;
 import com.google.android.gms.ads.LoadAdError;

--- a/android/src/main/java/com/matejdr/admanager/RNAdManagerNativeViewManager.java
+++ b/android/src/main/java/com/matejdr/admanager/RNAdManagerNativeViewManager.java
@@ -37,6 +37,7 @@ public class RNAdManagerNativeViewManager extends ViewGroupManager<NativeAdViewC
     public static final String PROP_TARGETING = "targeting";
     public static final String PROP_CORRELATOR = "correlator";
     public static final String PROP_SERVE_PERSONALIZED_ADS = "servePersonalizedAds";
+    public static final String PROP_ALLOW_DATA_PROCESSING = "allowDataProcessing";
 
 
     public static final String EVENT_AD_LOADED = "onAdLoaded";
@@ -227,6 +228,11 @@ public class RNAdManagerNativeViewManager extends ViewGroupManager<NativeAdViewC
     @ReactProp(name = PROP_SERVE_PERSONALIZED_ADS)
     public void setServePersonalizedAds(final NativeAdViewContainer view, final Boolean servePersonalizedAds) {
         view.setServePersonalizedAds(servePersonalizedAds);
+    }
+
+    @ReactProp(name = PROP_ALLOW_DATA_PROCESSING)
+    public void setAllowDataProcessing(final NativeAdViewContainer view, final Boolean allowDataProcessing) {
+        view.setAllowDataProcessing(allowDataProcessing);
     }
 
     @Override

--- a/android/src/main/java/com/matejdr/admanager/RNAdManagerNativeViewManager.java
+++ b/android/src/main/java/com/matejdr/admanager/RNAdManagerNativeViewManager.java
@@ -36,6 +36,8 @@ public class RNAdManagerNativeViewManager extends ViewGroupManager<NativeAdViewC
     public static final String PROP_VALID_AD_TYPES = "validAdTypes";
     public static final String PROP_TARGETING = "targeting";
     public static final String PROP_CORRELATOR = "correlator";
+    public static final String PROP_SERVE_PERSONALIZED_ADS = "servePersonalizedAds";
+
 
     public static final String EVENT_AD_LOADED = "onAdLoaded";
     public static final String EVENT_SIZE_CHANGE = "onSizeChange";
@@ -220,6 +222,11 @@ public class RNAdManagerNativeViewManager extends ViewGroupManager<NativeAdViewC
         ArrayList<Object> list = nativeArray.toArrayList();
         String[] customTemplateClickIdsStringArray = list.toArray(new String[list.size()]);
         view.setCustomClickTemplateIds(customTemplateClickIdsStringArray);
+    }
+
+    @ReactProp(name = PROP_SERVE_PERSONALIZED_ADS)
+    public void setServePersonalizedAds(final NativeAdViewContainer view, final Boolean servePersonalizedAds) {
+        view.setServePersonalizedAds(servePersonalizedAds);
     }
 
     @Override

--- a/ios/RNAdManageNativeManager.m
+++ b/ios/RNAdManageNativeManager.m
@@ -184,6 +184,7 @@ RCT_EXPORT_VIEW_PROPERTY(validAdSizes, NSArray)
 RCT_EXPORT_VIEW_PROPERTY(targeting, NSDictionary)
 RCT_EXPORT_VIEW_PROPERTY(correlator, NSString)
 RCT_EXPORT_VIEW_PROPERTY(servePersonalizedAds, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(allowDataProcessing, BOOL)
 
 RCT_EXPORT_VIEW_PROPERTY(onSizeChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onAppEvent, RCTBubblingEventBlock)

--- a/ios/RNAdManageNativeManager.m
+++ b/ios/RNAdManageNativeManager.m
@@ -180,6 +180,7 @@ RCT_EXPORT_VIEW_PROPERTY(adSize, NSString)
 RCT_EXPORT_VIEW_PROPERTY(validAdSizes, NSArray)
 RCT_EXPORT_VIEW_PROPERTY(targeting, NSDictionary)
 RCT_EXPORT_VIEW_PROPERTY(correlator, NSString)
+RCT_EXPORT_VIEW_PROPERTY(servePersonalizedAds, BOOL)
 
 RCT_EXPORT_VIEW_PROPERTY(onSizeChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onAppEvent, RCTBubblingEventBlock)

--- a/ios/RNAdManageNativeManager.m
+++ b/ios/RNAdManageNativeManager.m
@@ -137,9 +137,6 @@ RCT_EXPORT_METHOD(init:(NSString *)adUnitID testDevices:(NSArray *)testDevices)
         GADVideoOptions *videoOptions = [[GADVideoOptions alloc] init];
         videoOptions.startMuted = YES;
 
-        //Restrict data processing by default for all users
-        [NSUserDefaults.standardUserDefaults setBool:YES forKey:@"gad_rdp"];
-
         adLoader = [[GADAdLoader alloc] initWithAdUnitID:adUnitID
                                            rootViewController:[UIApplication sharedApplication].delegate.window.rootViewController
                                                       adTypes:adTypes

--- a/ios/RNAdManageNativeManager.m
+++ b/ios/RNAdManageNativeManager.m
@@ -91,7 +91,7 @@ RCT_EXPORT_METHOD(init:(NSString *)adUnitID testDevices:(NSArray *)testDevices)
 
     adsManager.adUnitID = adUnitID;
     adsManager.testDevices = RNAdManagerProcessTestDevices(testDevices, GADSimulatorID);
-    
+
     _myAdChoiceViewAdUnitID = adUnitID;
 
     [adsManagers setValue:adsManager forKey:adUnitID];
@@ -107,7 +107,7 @@ RCT_EXPORT_METHOD(init:(NSString *)adUnitID testDevices:(NSArray *)testDevices)
     if (adLoaders == nil) {
         adLoaders = [NSMutableDictionary new];
     }
-    
+
     NSString *adLoaderKey = adUnitID;
     if ([validAdTypes containsObject:@"native"]) {
         adLoaderKey = [NSString stringWithFormat:@"%@%@", adLoaderKey, @"native"];
@@ -136,6 +136,9 @@ RCT_EXPORT_METHOD(init:(NSString *)adUnitID testDevices:(NSArray *)testDevices)
 
         GADVideoOptions *videoOptions = [[GADVideoOptions alloc] init];
         videoOptions.startMuted = YES;
+
+        //Restrict data processing by default for all users
+        [NSUserDefaults.standardUserDefaults setBool:YES forKey:@"gad_rdp"];
 
         adLoader = [[GADAdLoader alloc] initWithAdUnitID:adUnitID
                                            rootViewController:[UIApplication sharedApplication].delegate.window.rootViewController

--- a/ios/RNAdManageNativeView.h
+++ b/ios/RNAdManageNativeView.h
@@ -34,6 +34,7 @@
 @property (nonatomic, copy) NSDictionary *targeting;
 @property (nonatomic, copy) NSString *correlator;
 @property (nonatomic) BOOL servePersonalizedAds;
+@property (nonatomic) BOOL allowDataProcessing;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onSizeChange;
 @property (nonatomic, copy) RCTBubblingEventBlock onAppEvent;

--- a/ios/RNAdManageNativeView.h
+++ b/ios/RNAdManageNativeView.h
@@ -33,6 +33,7 @@
 @property (nonatomic, copy) NSArray *validAdSizes;
 @property (nonatomic, copy) NSDictionary *targeting;
 @property (nonatomic, copy) NSString *correlator;
+@property (nonatomic) BOOL servePersonalizedAds;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onSizeChange;
 @property (nonatomic, copy) RCTBubblingEventBlock onAppEvent;

--- a/ios/RNAdManageNativeView.m
+++ b/ios/RNAdManageNativeView.m
@@ -143,10 +143,17 @@ static NSString *const kAdTypeTemplate = @"template";
     if (_correlator == nil) {
         _correlator = getCorrelator(_adUnitID);
     }
-    extras.additionalParameters = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                   _correlator, @"correlator",
-                                   nil];
-
+    
+    NSMutableDictionary *additionalParams = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
+                                             _correlator, @"correlator",
+                                             nil];
+    if (_servePersonalizedAds == NO) {
+        [additionalParams setObject:[NSNumber numberWithInt:1] forKey:@"npa"];
+    }
+    
+    // Set the dictionary to extras.additionalParameters
+    extras.additionalParameters = [NSDictionary dictionaryWithDictionary:additionalParams];
+    
     [request registerAdNetworkExtras:extras];
 
     if (_targeting != nil) {
@@ -236,6 +243,12 @@ static NSString *const kAdTypeTemplate = @"template";
 {
     _correlator = correlator;
 }
+
+- (void)setServePersonalizedAds:(BOOL)servePersonalizedAds
+{
+  _servePersonalizedAds = servePersonalizedAds;
+}
+
 
 #pragma mark GADAdLoaderDelegate implementation
 

--- a/ios/RNAdManageNativeView.m
+++ b/ios/RNAdManageNativeView.m
@@ -150,6 +150,10 @@ static NSString *const kAdTypeTemplate = @"template";
     if (_servePersonalizedAds == NO) {
         [additionalParams setObject:[NSNumber numberWithInt:1] forKey:@"npa"];
     }
+
+    if (_allowDataProcessing == NO) {
+        [additionalParams setObject:[NSNumber numberWithInt:1] forKey:@"rdp"];
+    }
     
     // Set the dictionary to extras.additionalParameters
     extras.additionalParameters = [NSDictionary dictionaryWithDictionary:additionalParams];
@@ -247,6 +251,11 @@ static NSString *const kAdTypeTemplate = @"template";
 - (void)setServePersonalizedAds:(BOOL)servePersonalizedAds
 {
   _servePersonalizedAds = servePersonalizedAds;
+}
+
+- (void)setAllowDataProcessing:(BOOL)allowDataProcessing
+{
+  _allowDataProcessing = allowDataProcessing;
 }
 
 

--- a/ios/RNAdManagerAdaptiveBannerView.h
+++ b/ios/RNAdManagerAdaptiveBannerView.h
@@ -9,6 +9,7 @@
 @property (nonatomic, copy) NSNumber *maxHeight;
 @property (nonatomic, strong) NSString *adUnitID;
 @property (nonatomic, copy) NSString *correlator;
+@property (nonatomic) BOOL servePersonalizedAds;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onSizeChange;
 @property (nonatomic, copy) RCTBubblingEventBlock onAppEvent;

--- a/ios/RNAdManagerAdaptiveBannerView.h
+++ b/ios/RNAdManagerAdaptiveBannerView.h
@@ -10,6 +10,7 @@
 @property (nonatomic, strong) NSString *adUnitID;
 @property (nonatomic, copy) NSString *correlator;
 @property (nonatomic) BOOL servePersonalizedAds;
+@property (nonatomic) BOOL allowDataProcessing;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onSizeChange;
 @property (nonatomic, copy) RCTBubblingEventBlock onAppEvent;

--- a/ios/RNAdManagerAdaptiveBannerView.m
+++ b/ios/RNAdManagerAdaptiveBannerView.m
@@ -53,6 +53,12 @@
   _correlator = correlator;
 }
 
+- (void)setServePersonalizedAds:(BOOL)servePersonalizedAds
+{
+  _servePersonalizedAds = servePersonalizedAds;
+}
+
+
 // Initialise BannerAdView as soon as all the props are set
 - (void)createViewIfCan
 {
@@ -110,9 +116,17 @@
     if (_correlator == nil) {
         _correlator = getCorrelator(_adUnitID);
     }
-    extras.additionalParameters = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                   _correlator, @"correlator",
-                                   nil];
+    
+    NSMutableDictionary *additionalParams = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
+                                             _correlator, @"correlator",
+                                             nil];
+    if (_servePersonalizedAds == NO) {
+        [additionalParams setObject:[NSNumber numberWithInt:1] forKey:@"npa"];
+    }
+    
+    // Set the dictionary to extras.additionalParameters
+    extras.additionalParameters = [NSDictionary dictionaryWithDictionary:additionalParams];
+    
     [request registerAdNetworkExtras:extras];
 
     if (_targeting != nil) {

--- a/ios/RNAdManagerAdaptiveBannerView.m
+++ b/ios/RNAdManagerAdaptiveBannerView.m
@@ -58,6 +58,11 @@
   _servePersonalizedAds = servePersonalizedAds;
 }
 
+- (void)setAllowDataProcessing:(BOOL)allowDataProcessing
+{
+  _allowDataProcessing = allowDataProcessing;
+}
+
 
 // Initialise BannerAdView as soon as all the props are set
 - (void)createViewIfCan
@@ -122,6 +127,9 @@
                                              nil];
     if (_servePersonalizedAds == NO) {
         [additionalParams setObject:[NSNumber numberWithInt:1] forKey:@"npa"];
+    }
+    if (_allowDataProcessing == NO) {
+        [additionalParams setObject:[NSNumber numberWithInt:1] forKey:@"rdp"];
     }
     
     // Set the dictionary to extras.additionalParameters

--- a/ios/RNAdManagerAdaptiveBannerViewManager.m
+++ b/ios/RNAdManagerAdaptiveBannerViewManager.m
@@ -41,6 +41,7 @@ RCT_EXPORT_VIEW_PROPERTY(correlator, NSString)
 RCT_EXPORT_VIEW_PROPERTY(testDevices, NSArray)
 RCT_EXPORT_VIEW_PROPERTY(targeting, NSDictionary)
 RCT_EXPORT_VIEW_PROPERTY(servePersonalizedAds, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(allowDataProcessing, BOOL)
 
 RCT_EXPORT_VIEW_PROPERTY(onSizeChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onAppEvent, RCTBubblingEventBlock)

--- a/ios/RNAdManagerAdaptiveBannerViewManager.m
+++ b/ios/RNAdManagerAdaptiveBannerViewManager.m
@@ -40,6 +40,7 @@ RCT_EXPORT_VIEW_PROPERTY(adUnitID, NSString)
 RCT_EXPORT_VIEW_PROPERTY(correlator, NSString)
 RCT_EXPORT_VIEW_PROPERTY(testDevices, NSArray)
 RCT_EXPORT_VIEW_PROPERTY(targeting, NSDictionary)
+RCT_EXPORT_VIEW_PROPERTY(servePersonalizedAds, BOOL)
 
 RCT_EXPORT_VIEW_PROPERTY(onSizeChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onAppEvent, RCTBubblingEventBlock)

--- a/ios/RNAdManagerBannerView.h
+++ b/ios/RNAdManagerBannerView.h
@@ -9,6 +9,7 @@
 @property (nonatomic, copy) NSString *adSize;
 @property (nonatomic, strong) NSString *adUnitID;
 @property (nonatomic, copy) NSString *correlator;
+@property (nonatomic) BOOL servePersonalizedAds;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onSizeChange;
 @property (nonatomic, copy) RCTBubblingEventBlock onAppEvent;

--- a/ios/RNAdManagerBannerView.h
+++ b/ios/RNAdManagerBannerView.h
@@ -10,6 +10,7 @@
 @property (nonatomic, strong) NSString *adUnitID;
 @property (nonatomic, copy) NSString *correlator;
 @property (nonatomic) BOOL servePersonalizedAds;
+@property (nonatomic) BOOL allowDataProcessing;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onSizeChange;
 @property (nonatomic, copy) RCTBubblingEventBlock onAppEvent;

--- a/ios/RNAdManagerBannerView.m
+++ b/ios/RNAdManagerBannerView.m
@@ -64,6 +64,11 @@
   _correlator = correlator;
 }
 
+- (void)setServePersonalizedAds:(BOOL)servePersonalizedAds
+{
+  _servePersonalizedAds = servePersonalizedAds;
+}
+
 // Initialise BannerAdView as soon as all the props are set
 - (void)createViewIfCan
 {
@@ -97,9 +102,17 @@
     if (_correlator == nil) {
         _correlator = getCorrelator(_adUnitID);
     }
-    extras.additionalParameters = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                   _correlator, @"correlator",
-                                   nil];
+    
+    NSMutableDictionary *additionalParams = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
+                                             _correlator, @"correlator",
+                                             nil];
+    if (_servePersonalizedAds == NO) {
+        [additionalParams setObject:[NSNumber numberWithInt:1] forKey:@"npa"];
+    }
+    
+    // Set the dictionary to extras.additionalParameters
+    extras.additionalParameters = [NSDictionary dictionaryWithDictionary:additionalParams];
+    
     [request registerAdNetworkExtras:extras];
 
     if (_targeting != nil) {

--- a/ios/RNAdManagerBannerView.m
+++ b/ios/RNAdManagerBannerView.m
@@ -69,6 +69,11 @@
   _servePersonalizedAds = servePersonalizedAds;
 }
 
+- (void)setAllowDataProcessing:(BOOL)allowDataProcessing
+{
+  _allowDataProcessing = allowDataProcessing;
+}
+
 // Initialise BannerAdView as soon as all the props are set
 - (void)createViewIfCan
 {
@@ -108,6 +113,10 @@
                                              nil];
     if (_servePersonalizedAds == NO) {
         [additionalParams setObject:[NSNumber numberWithInt:1] forKey:@"npa"];
+    }
+
+    if (_allowDataProcessing == NO) {
+        [additionalParams setObject:[NSNumber numberWithInt:1] forKey:@"rdp"];
     }
     
     // Set the dictionary to extras.additionalParameters

--- a/ios/RNAdManagerBannerViewManager.m
+++ b/ios/RNAdManagerBannerViewManager.m
@@ -46,6 +46,7 @@ RCT_EXPORT_VIEW_PROPERTY(validAdSizes, NSArray)
 RCT_EXPORT_VIEW_PROPERTY(testDevices, NSArray)
 RCT_EXPORT_VIEW_PROPERTY(targeting, NSDictionary)
 RCT_EXPORT_VIEW_PROPERTY(servePersonalizedAds, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(allowDataProcessing, BOOL)
 
 RCT_EXPORT_VIEW_PROPERTY(onSizeChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onAppEvent, RCTBubblingEventBlock)

--- a/ios/RNAdManagerBannerViewManager.m
+++ b/ios/RNAdManagerBannerViewManager.m
@@ -45,6 +45,7 @@ RCT_EXPORT_VIEW_PROPERTY(correlator, NSString)
 RCT_EXPORT_VIEW_PROPERTY(validAdSizes, NSArray)
 RCT_EXPORT_VIEW_PROPERTY(testDevices, NSArray)
 RCT_EXPORT_VIEW_PROPERTY(targeting, NSDictionary)
+RCT_EXPORT_VIEW_PROPERTY(servePersonalizedAds, BOOL)
 
 RCT_EXPORT_VIEW_PROPERTY(onSizeChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onAppEvent, RCTBubblingEventBlock)

--- a/ios/RNAdManagerInterstitial.m
+++ b/ios/RNAdManagerInterstitial.m
@@ -16,6 +16,7 @@ static NSString *const kEventAdClosed = @"interstitialAdClosed";
     NSArray *_testDevices;
     NSDictionary *_targeting;
     BOOL _servePersonalizedAds;
+    BOOL _allowDataProcessing;
 
     RCTPromiseResolveBlock _requestAdResolve;
     RCTPromiseRejectBlock _requestAdReject;
@@ -66,6 +67,11 @@ RCT_EXPORT_METHOD(setServePersonalizedAds:(BOOL) servePersonalizedAds)
     _servePersonalizedAds = servePersonalizedAds;
 }
 
+RCT_EXPORT_METHOD(setAllowDataProcessing:(BOOL) allowDataProcessing)
+{
+    _allowDataProcessing = allowDataProcessing;
+}
+
 RCT_EXPORT_METHOD(requestAd:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
     _requestAdResolve = nil;
@@ -79,11 +85,20 @@ RCT_EXPORT_METHOD(requestAd:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromise
         GADMobileAds.sharedInstance.requestConfiguration.testDeviceIdentifiers = _testDevices;
         GAMRequest *request = [GAMRequest request];
         
-        if (_servePersonalizedAds == NO) {
+        if (_servePersonalizedAds == NO || _allowDataProcessing == NO) {
             GADExtras *extras = [[GADExtras alloc] init];
-            extras.additionalParameters = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                           [NSNumber numberWithInt:1], @"npa",
-                                           nil];
+    
+            NSMutableDictionary *parameters = [[NSMutableDictionary alloc] init];
+
+            if (_servePersonalizedAds == NO) {
+                [parameters setObject:[NSNumber numberWithInt:1] forKey:@"npa"];
+            }
+    
+            if (_allowDataProcessing == NO) {
+                [parameters setObject:[NSNumber numberWithInt:1] forKey:@"rdp"];
+            }
+    
+            extras.additionalParameters = parameters;
             [request registerAdNetworkExtras:extras];
         }
 

--- a/ios/RNAdManagerInterstitial.m
+++ b/ios/RNAdManagerInterstitial.m
@@ -15,6 +15,7 @@ static NSString *const kEventAdClosed = @"interstitialAdClosed";
     NSString *_adUnitID;
     NSArray *_testDevices;
     NSDictionary *_targeting;
+    BOOL _servePersonalizedAds;
 
     RCTPromiseResolveBlock _requestAdResolve;
     RCTPromiseRejectBlock _requestAdReject;
@@ -60,6 +61,11 @@ RCT_EXPORT_METHOD(setTargeting:(NSDictionary *)targeting)
     _targeting = targeting;
 }
 
+RCT_EXPORT_METHOD(setServePersonalizedAds:(BOOL) servePersonalizedAds)
+{
+    _servePersonalizedAds = servePersonalizedAds;
+}
+
 RCT_EXPORT_METHOD(requestAd:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
     _requestAdResolve = nil;
@@ -72,6 +78,14 @@ RCT_EXPORT_METHOD(requestAd:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromise
 
         GADMobileAds.sharedInstance.requestConfiguration.testDeviceIdentifiers = _testDevices;
         GAMRequest *request = [GAMRequest request];
+        
+        if (_servePersonalizedAds == NO) {
+            GADExtras *extras = [[GADExtras alloc] init];
+            extras.additionalParameters = [[NSDictionary alloc] initWithObjectsAndKeys:
+                                           [NSNumber numberWithInt:1], @"npa",
+                                           nil];
+            [request registerAdNetworkExtras:extras];
+        }
 
         if (_targeting != nil) {
             NSDictionary *customTargeting = [_targeting objectForKey:@"customTargeting"];

--- a/src/CTKAdManagerAdaptiveBanner.tsx
+++ b/src/CTKAdManagerAdaptiveBanner.tsx
@@ -44,6 +44,8 @@ interface IAdManagerAdaptiveBannerPropsBase extends ViewProps {
   testDevices?: string[];
 
   targeting?: IAdManagerTargeting;
+
+  servePersonalizedAds?: boolean;
 }
 
 interface IAdManagerAdaptiveBannerProps

--- a/src/CTKAdManagerBanner.tsx
+++ b/src/CTKAdManagerBanner.tsx
@@ -5,8 +5,8 @@ import {
   ViewProps,
   findNodeHandle,
   NativeSyntheticEvent,
-  DeviceEventEmitter,  
-  EventSubscription
+  DeviceEventEmitter,
+  EventSubscription,
 } from 'react-native';
 import { createErrorFromErrorData } from './utils';
 import type {
@@ -52,10 +52,12 @@ interface IAdManagerBannerPropsBase extends ViewProps {
   testDevices?: string[];
 
   targeting?: IAdManagerTargeting;
+
+  servePersonalizedAds?: boolean;
 }
 
 interface IAdManagerBannerProps extends IAdManagerBannerPropsBase {
-  // onError is a callback function sent from parent RN component of your RN app, aka: the error handler. 
+  // onError is a callback function sent from parent RN component of your RN app, aka: the error handler.
   // so if your RN App wants to handle the error, please pass in the "onError" function.
   onError?: (eventData: Error) => void;
   /**
@@ -92,7 +94,9 @@ interface IAdManagerBannerNativeProps extends IAdManagerBannerPropsBase {
   onAppEvent?: (event: NativeSyntheticEvent<IAdManagerEventAppEvent>) => void;
   onAdOpened?: (event: NativeSyntheticEvent<IAdManagerEventBase>) => void;
   onAdClosed?: (event: NativeSyntheticEvent<IAdManagerEventBase>) => void;
-  onAdRecordImpression?: (event: NativeSyntheticEvent<IAdManagerEventBase>) => void;
+  onAdRecordImpression?: (
+    event: NativeSyntheticEvent<IAdManagerEventBase>
+  ) => void;
 }
 
 const ComponentName = 'CTKBannerView';
@@ -113,7 +117,10 @@ export class Banner extends React.Component<
 
   constructor(props: IAdManagerBannerProps) {
     super(props);
-    this.hasOnErrorFromParent = Object.prototype.hasOwnProperty.call(props, 'onError');
+    this.hasOnErrorFromParent = Object.prototype.hasOwnProperty.call(
+      props,
+      'onError'
+    );
     this.handleSizeChange = this.handleSizeChange.bind(this);
     this.state = {
       style: {},
@@ -137,21 +144,24 @@ export class Banner extends React.Component<
   }
 
   componentDidMount() {
-    this.customListener= DeviceEventEmitter.addListener('onError',eventData=>{
-      this.setState({ error: eventData });
-      if (this.hasOnErrorFromParent && this.props.onError) {      
-        this.props.onError(eventData);
+    this.customListener = DeviceEventEmitter.addListener(
+      'onError',
+      (eventData) => {
+        this.setState({ error: eventData });
+        if (this.hasOnErrorFromParent && this.props.onError) {
+          this.props.onError(eventData);
+        }
       }
-    });    
+    );
     this.loadBanner();
   }
-  
+
   componentWillUnmount() {
     if (this.customListener) {
       this.customListener.remove();
     }
   }
-  
+
   loadBanner() {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this),
@@ -191,7 +201,8 @@ export class Banner extends React.Component<
           this.props.onAdClosed && this.props.onAdClosed(event.nativeEvent)
         }
         onAdRecordImpression={(event) =>
-          this.props.onAdRecordImpression && this.props.onAdRecordImpression(event.nativeEvent)
+          this.props.onAdRecordImpression &&
+          this.props.onAdRecordImpression(event.nativeEvent)
         }
       />
     );

--- a/src/CTKAdManagerInterstitial.ts
+++ b/src/CTKAdManagerInterstitial.ts
@@ -101,17 +101,21 @@ const setTargeting = (targeting: IAdManagerTargeting) => {
   CTKInterstitial.setTargeting(targeting);
 };
 
+const setServePersonalizedAds = (servePersonalizedAds: boolean) => {
+  CTKInterstitial.setServePersonalizedAds(servePersonalizedAds);
+};
+
 const requestAd = (): Promise<null> => {
   return CTKInterstitial.requestAd();
-}
+};
 
 const showAd = (): Promise<null> => {
   return CTKInterstitial.showAd();
-}
+};
 
 const isReady = (callback: (isReady: boolean) => void): Promise<null> => {
   return CTKInterstitial.isReady(callback);
-}
+};
 
 export default {
   addEventListener,
@@ -123,5 +127,6 @@ export default {
   setTargeting,
   requestAd,
   showAd,
-  isReady
-}
+  setServePersonalizedAds,
+  isReady,
+};

--- a/src/CTKAdManagerInterstitial.ts
+++ b/src/CTKAdManagerInterstitial.ts
@@ -105,6 +105,10 @@ const setServePersonalizedAds = (servePersonalizedAds: boolean) => {
   CTKInterstitial.setServePersonalizedAds(servePersonalizedAds);
 };
 
+const setAllowDataProcessing = (allowDataProcessing: boolean) => {
+  CTKInterstitial.setAllowDataProcessing(allowDataProcessing);
+};
+
 const requestAd = (): Promise<null> => {
   return CTKInterstitial.requestAd();
 };
@@ -128,5 +132,6 @@ export default {
   requestAd,
   showAd,
   setServePersonalizedAds,
+  setAllowDataProcessing,
   isReady,
 };

--- a/src/native-ads/withNativeAd.tsx
+++ b/src/native-ads/withNativeAd.tsx
@@ -37,6 +37,7 @@ interface INativeAdPropsBase extends ViewProps {
   validAdTypes?: ('banner' | 'native' | 'template')[];
   customClickTemplateIds?: string[];
   targeting?: IAdManagerTargeting;
+  servePersonalizedAds?: boolean;
 }
 
 interface INativeAdNativeProps extends INativeAdPropsBase {
@@ -60,7 +61,9 @@ interface INativeAdNativeProps extends INativeAdPropsBase {
   onAdCustomClick?: (
     event: NativeSyntheticEvent<IAdManagerEventCustomClick>
   ) => void;
-  onAdRecordImpression?: (event: NativeSyntheticEvent<IAdManagerEventBase>) => void;
+  onAdRecordImpression?: (
+    event: NativeSyntheticEvent<IAdManagerEventBase>
+  ) => void;
 }
 
 interface INativeAdProps extends INativeAdPropsBase {
@@ -276,11 +279,13 @@ export default (Component: JSXElementConstructor<any>) =>
             this.props.onAdCustomClick(event.nativeEvent)
           }
           onAdRecordImpression={(event) =>
-            this.props.onAdRecordImpression && this.props.onAdRecordImpression(event.nativeEvent)
+            this.props.onAdRecordImpression &&
+            this.props.onAdRecordImpression(event.nativeEvent)
           }
           targeting={this.props.targeting}
           customClickTemplateIds={this.props.customClickTemplateIds}
           adsManager={adsManager.toJSON()}
+          servePersonalizedAds={this.props.servePersonalizedAds}
         >
           {this.renderAdComponent(rest)}
         </NativeAdView>

--- a/src/native-ads/withNativeAd.tsx
+++ b/src/native-ads/withNativeAd.tsx
@@ -38,6 +38,7 @@ interface INativeAdPropsBase extends ViewProps {
   customClickTemplateIds?: string[];
   targeting?: IAdManagerTargeting;
   servePersonalizedAds?: boolean;
+  allowDataProcessing?: boolean;
 }
 
 interface INativeAdNativeProps extends INativeAdPropsBase {
@@ -286,6 +287,7 @@ export default (Component: JSXElementConstructor<any>) =>
           customClickTemplateIds={this.props.customClickTemplateIds}
           adsManager={adsManager.toJSON()}
           servePersonalizedAds={this.props.servePersonalizedAds}
+          allowDataProcessing={this.props.allowDataProcessing}
         >
           {this.renderAdComponent(rest)}
         </NativeAdView>


### PR DESCRIPTION
Setting `servePersonalizedAds` and `allowDataProcessing` to `false` in the Android code.

On iOS, booleans are `false` by default and not being set to `true` anywhere, so I just added some minor missing code there